### PR TITLE
Quick fix of col.lines

### DIFF
--- a/R/slopegraph.r
+++ b/R/slopegraph.r
@@ -148,7 +148,7 @@ slopegraph <- function(
             x2 <- e[eok, 1]
             y1 <- datarow[x1]
             y2 <- datarow[x2]
-            cbind(x1, y1, x2, y2)
+            cbind(x1, y1, x2, y2, n)
         } else {
             NULL
         }
@@ -159,6 +159,7 @@ slopegraph <- function(
             y1 <- rowdata[2]
             x2 <- rowdata[3]
             y2 <- rowdata[4]
+            i <- rowdata[5]
             ysloped <- (y2-y1)*offset.x
             segments(x1+offset.x, if(y1==y2) y1 else (y1+ysloped),
                      x2-offset.x, if(y1==y2) y2 else (y2-ysloped),


### PR DESCRIPTION
the line col = col.lines[i] (and lty=lty[i],
                     lwd=lwd[i]) were not functioning as ‘i’ is
undefined in the ‘apply’ function. We can pass the index of the line in
question from todraw by adding it as a column. Then it is a simple
matter of defining i as rowdata[5], and the function works as expected.