### PR TITLE
Remove e from install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ To install the latest development version of **slopegraph** from GitHub:
 if (!require("ghit")) {
     install.packages("ghit")
 }
-ghite::install_github("leeper/slopegraph")
+ghit::install_github("leeper/slopegraph")
 ```
 


### PR DESCRIPTION
The install command did not work, I replace `ghite::install_github("leeper/slopegraph")` by `ghit::install_github("leeper/slopegraph")`