### PR TITLE
ggslopegraph2 arguments format text labels

### DIFF
--- a/R/ggslopegraph2.R
+++ b/R/ggslopegraph2.R
@@ -39,6 +39,10 @@
 #' "Others" = "gray", "PC" = "blue"). Any input must be character, and the length 
 #' of a vector \bold{should} equal the number of levels in \code{Grouping}. If the 
 #' user does not provide enough colors they will be recycled.
+#' @param datatextfamily Optionally the font family of the plotted data points. datatextfamily = "sans" is the default.
+#' @param datatextface Optionally the font face of the plotted data points. datatextface = "plain" is the default.
+#' @param labeltextfamily Optionally the font family of the grouping labels. labeltextfamily = "sans" is the default.
+#' @param labeltextface Optionally the font face of the grouping labels. labeltextface = "bold" is the default.
 #' 
 #' @return A \code{\link[ggplot2]{ggplot}} object.
 #' @author Chuck Powell
@@ -87,7 +91,11 @@ ggslopegraph2 <-
     captiontextsize = 8,
     linethickness = 1,
     linecolor = "ByGroup",
-    datatextsize = 2.5
+    datatextsize = 2.5,
+    datatextfamily = "sans",
+    datatextface = "plain",
+    labeltextfamily = "sans",
+    labeltextface = "bold"
   ) {
     # Since ggplot2 objects are just regular R objects, put them in a list
     my_special <- list(
@@ -173,18 +181,22 @@ ggslopegraph2 <-
       geom_text_repel(data = dataframe %>% filter(!! times == min(!! times)),
                       aes_(label = grouping) ,
                       hjust = "left",
-                      fontface = "bold",
+                      fontface = labeltextface,
+                      family = labeltextfamily,
                       size = ytextsize,
                       nudge_x = -.45,
                       direction = "y") +
       geom_text_repel(data = dataframe %>% filter(!! times == max(!! times)),
                       aes_(label = grouping),
                       hjust = "right",
-                      fontface = "bold",
+                      fontface = labeltextface,
+                      family = labeltextfamily,
                       size = ytextsize,
                       nudge_x = .5,
                       direction = "y") +
-      geom_label(aes_(label = measurement), size = datatextsize, label.padding = unit(0.05, "lines"), label.size = 0.0) +
+      geom_label(aes_(label = measurement), size = datatextsize, 
+                 label.padding = unit(0.05, "lines"), label.size = 0.0,
+                 fontface = datatextface, family = datatextfamily) +
       my_special +
       labs(
         title = title,

--- a/man/ggslopegraph2.Rd
+++ b/man/ggslopegraph2.Rd
@@ -7,7 +7,9 @@
 ggslopegraph2(dataframe, times, measurement, grouping, title = "",
   subtitle = "", caption = "", xtextsize = 12, ytextsize = 3,
   titletextsize = 14, subtitletextsize = 10, captiontextsize = 8,
-  linethickness = 1, linecolor = "ByGroup", datatextsize = 2.5)
+  linethickness = 1, linecolor = "ByGroup", datatextsize = 2.5,
+  datatextfamily = "sans", datatextface = "plain",
+  labeltextfamily = "sans", labeltextface = "bold")
 }
 \arguments{
 \item{dataframe}{a dataframe or an object that can be coerced to a dataframe. 
@@ -56,6 +58,14 @@ of a vector \bold{should} equal the number of levels in \code{Grouping}. If the
 user does not provide enough colors they will be recycled.}
 
 \item{datatextsize}{Optionally the font size of the plotted data points. datatextsize = 2.5 is the default must be a numeric.}
+
+\item{datatextfamily}{Optionally the font family of the plotted data points. datatextfamily = "sans" is the default.}
+
+\item{datatextface}{Optionally the font face of the plotted data points. datatextface = "plain" is the default.}
+
+\item{labeltextfamily}{Optionally the font family of the grouping labels. labeltextfamily = "sans" is the default.}
+
+\item{labeltextface}{Optionally the font face of the grouping labels. labeltextface = "bold" is the default.}
 }
 \value{
 A \code{\link[ggplot2]{ggplot}} object.


### PR DESCRIPTION
Add arguments to `ggslopegraph2` that allow user to specify fontface and font family used by labels.

- `datatextfamily` - specifies font family of the plotted data points. defaults to `datatextfamily = "sans"`

- `datatextface` - specifies font face of the plotted data points. defaults to `datatextface = "plain"`

- `labeltextfamily` - specifies font family of the grouping labels. defaults to `labeltextfamily = "sans"`

- `labeltextface` - specifies font face of the grouping labels. defaults to `labeltextface = "bold"`

Example:
``` r
ggslopegraph2(cancer2, Year, Survival, Type, 
    datatextfamily = "serif", datatextface = "bold", 
    labeltextfamily = "serif", labeltextface = "plain")
```

![image](https://user-images.githubusercontent.com/11282246/43660145-c0673af8-9723-11e8-8b64-a7c0193532b6.png)
